### PR TITLE
Add support for class-based matching, hiding from taskbars and switchers, and logging

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -2,6 +2,7 @@
 const config = {
     windowNamePrefix: null,
     windowNameSuffix: null,
+    windowClassName: null,
     command: null,
     loggingEnabled: true,
 };
@@ -15,6 +16,7 @@ function log(...params) {
 function loadConfiguration() {
     config.windowNamePrefix = readConfig("windowNamePrefix", "foot").toString();
     config.windowNameSuffix = readConfig("windowNameSuffix", "").toString();
+    config.windowClassName = readConfig("windowClassName", "").toString();
     config.launchCommand = readConfig("launchCommand", "/usr/bin/foot").toString();
     config.loggingEnabled = readConfig("debugLoggingEnabled", "false").toString() === "true";
     console.log("Starting with logging enabled?", config.loggingEnabled);
@@ -29,6 +31,7 @@ function isTerminal(window) {
         window.caption.substr(0, config.windowNamePrefix.length) === config.windowNamePrefix
         &&
         window.caption.substr(-1 * config.windowNameSuffix.length, config.windowNameSuffix.length) === config.windowNameSuffix
+        && config.windowClassName.trim() !== '' ? window.resourceClass === config.windowClassName : true
     );
 }
 function launchTerminal() {

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -18,6 +18,22 @@
             <label>Command for launching the terminal application if the window can not be found</label>
             <default>/usr/bin/foot</default>
         </entry>
+        <entry name="skipTaskbarSettingEnabled" type="Bool">
+            <label>Whether or not the setting for skipping the taskbar should be honored.</label>
+            <default>false</default>
+        </entry>
+        <entry name="skipTaskbar" type="Bool">
+            <label>Whether or not the window should be shown in the taskbar</label>
+            <default>false</default>
+        </entry>
+        <entry name="skipSwitcherSettingEnabled" type="Bool">
+            <label>Whether or not the setting for skipping the window switcher should be enabled</label>
+            <default>false</default>
+        </entry>
+        <entry name="skipSwitcher" type="Bool">
+            <label>Whether or not the window should be shown in the window switcher</label>
+            <default>false</default>
+        </entry>
         <entry name="debugLoggingEnabled" type="Bool">
             <label>Enable this if you wish to perform debug logging.</label>
             <default>false</default>

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -14,5 +14,9 @@
             <label>Command for launching the terminal application if the window can not be found</label>
             <default>/usr/bin/foot</default>
         </entry>
+        <entry name="debugLoggingEnabled" type="Bool">
+            <label>Enable this if you wish to perform debug logging.</label>
+            <default>false</default>
+        </entry>
     </group>
 </kcfg>

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -10,6 +10,10 @@
             <label>Suffix of the window name used for detecting the terminal</label>
             <default></default>
         </entry>
+        <entry name="windowClassName" type="String">
+            <label>Suffix of the window name used for detecting the terminal</label>
+            <default></default>
+        </entry>
         <entry name="launchCommand" type="String">
             <label>Command for launching the terminal application if the window can not be found</label>
             <default>/usr/bin/foot</default>

--- a/contents/ui/config.ui
+++ b/contents/ui/config.ui
@@ -104,6 +104,48 @@
                 </widget>
             </item>
             <item row="8" column="0">
+                <layout class="QHBoxLayout" name="horizontalLayout_skipTaskbar">
+                    <item>
+                        <widget class="QCheckBox" name="kcfg_skipTaskbarSettingEnabled">
+                            <property name="text">
+                                <string>Enabled?</string>
+                            </property>
+                        </widget>
+                   </item>
+                   <item>
+                        <widget class="QCheckBox" name="kcfg_skipTaskbar">
+                            <property name="enabled">
+                                <bool>false</bool>
+                            </property>
+                            <property name="text">
+                                <string>Skip taskbar?</string>
+                            </property>
+                        </widget>
+                    </item>
+                </layout>
+            </item>
+            <item row="9" column="0">
+                <layout class="QHBoxLayout" name="horizontalLayout_skipSwitcher">
+                    <item>
+                        <widget class="QCheckBox" name="kcfg_skipSwitcherSettingEnabled">
+                            <property name="text">
+                                <string>Enabled?</string>
+                            </property>
+                        </widget>
+                    </item>
+                    <item>
+                        <widget class="QCheckBox" name="kcfg_skipSwitcher">
+                            <property name="enabled">
+                                <bool>false</bool>
+                            </property>
+                            <property name="text">
+                                <string>Skip switcher?</string>
+                            </property>
+                        </widget>
+                    </item>
+                </layout>
+            </item>
+            <item row="10" column="0">
                 <widget class="QCheckBox" name="kcfg_debugLoggingEnabled">
                     <property name="text">
                         <string>Debug logging?</string>
@@ -113,5 +155,18 @@
         </layout>
     </widget>
     <resources/>
-    <connections/>
+    <connections>
+        <connection>
+            <sender>kcfg_skipTaskbarSettingEnabled</sender>
+            <signal>toggled(bool)</signal>
+            <receiver>kcfg_skipTaskbar</receiver>
+            <slot>setEnabled(bool)</slot>
+        </connection>
+        <connection>
+            <sender>kcfg_skipSwitcherSettingEnabled</sender>
+            <signal>toggled(bool)</signal>
+            <receiver>kcfg_skipSwitcher</receiver>
+            <slot>setEnabled(bool)</slot>
+        </connection>
+    </connections>
 </ui>

--- a/contents/ui/config.ui
+++ b/contents/ui/config.ui
@@ -1,98 +1,117 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>KWin::ToggleTerminalConfigForm</class>
- <widget class="QWidget" name="KWin::ToggleTerminalConfigForm">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>147</width>
-    <height>254</height>
-   </rect>
-  </property>
-  <layout class="QGridLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Window name prefix</string>
-     </property>
+    <class>KWin::ToggleTerminalConfigForm</class>
+    <widget class="QWidget" name="KWin::ToggleTerminalConfigForm">
+        <property name="geometry">
+            <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>147</width>
+                <height>254</height>
+            </rect>
+        </property>
+        <layout class="QGridLayout">
+            <item row="0" column="0">
+                <widget class="QLabel" name="label">
+                    <property name="text">
+                        <string>Window name prefix</string>
+                    </property>
+                </widget>
+            </item>
+            <item row="6" column="0">
+                <widget class="QLabel" name="label">
+                    <property name="text">
+                        <string>Launch command</string>
+                    </property>
+                </widget>
+            </item>
+            <item row="5" column="0">
+                <widget class="QLineEdit" name="kcfg_windowClassName">
+                    <property name="toolTip">
+                        <string>
+                            Name of the window class used for detecting the
+                            terminal.
+                        </string>
+                    </property>
+                    <property name="statusTip">
+                        <string>Window class</string>
+                    </property>
+                    <property name="whatsThis">
+                        <string>Window name suffix</string>
+                    </property>
+                </widget>
+            </item>
+            <item row="7" column="0">
+                <widget class="QLineEdit" name="kcfg_launchCommand">
+                    <property name="toolTip">
+                        <string>
+                            Command for launching the terminal application if
+                            the window can not be found.
+                        </string>
+                    </property>
+                    <property name="statusTip">
+                        <string>Launch command</string>
+                    </property>
+                    <property name="whatsThis">
+                        <string>Launch command</string>
+                    </property>
+                </widget>
+            </item>
+            <item row="1" column="0">
+                <widget class="QLineEdit" name="kcfg_windowNamePrefix">
+                    <property name="toolTip">
+                        <string>
+                            Prefix of the window name used for detecting the
+                            terminal.
+                        </string>
+                    </property>
+                    <property name="statusTip">
+                        <string>Window name prefix</string>
+                    </property>
+                    <property name="whatsThis">
+                        <string>Window name prefix</string>
+                    </property>
+                </widget>
+            </item>
+            <item row="2" column="0">
+                <widget class="QLabel" name="label">
+                    <property name="text">
+                        <string>Window name suffix</string>
+                    </property>
+                </widget>
+            </item>
+            <item row="3" column="0">
+                <widget class="QLineEdit" name="kcfg_windowNameSuffix">
+                    <property name="toolTip">
+                        <string>
+                            Suffix of the window name used for detecting the
+                            terminal.
+                        </string>
+                    </property>
+                    <property name="statusTip">
+                        <string>Window name suffix</string>
+                    </property>
+                    <property name="whatsThis">
+                        <string>Window name suffix</string>
+                    </property>
+                </widget>
+            </item>
+            <item row="4" column="0">
+                <widget class="QLabel" name="label">
+                    <property name="text">
+                        <string>Window class</string>
+                    </property>
+                </widget>
+            </item>
+            <item row="8" column="0">
+                <widget class="QCheckBox" name="kcfg_debugLoggingEnabled">
+                    <property name="text">
+                        <string>Debug logging?</string>
+                    </property>
+                </widget>
+            </item>
+        </layout>
     </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Launch command</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLineEdit" name="kcfg_windowClassName">
-     <property name="toolTip">
-      <string>Name of the window class used for detecting the terminal.</string>
-     </property>
-     <property name="statusTip">
-      <string>Window class</string>
-     </property>
-     <property name="whatsThis">
-      <string>Window name suffix</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0">
-    <widget class="QLineEdit" name="kcfg_launchCommand">
-     <property name="toolTip">
-      <string>Command for launching the terminal application if the window can not be found.</string>
-     </property>
-     <property name="statusTip">
-      <string>Launch command</string>
-     </property>
-     <property name="whatsThis">
-      <string>Launch command</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLineEdit" name="kcfg_windowNamePrefix">
-     <property name="toolTip">
-      <string>Prefix of the window name used for detecting the terminal.</string>
-     </property>
-     <property name="statusTip">
-      <string>Window name prefix</string>
-     </property>
-     <property name="whatsThis">
-      <string>Window name prefix</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Window name suffix</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLineEdit" name="kcfg_windowNameSuffix">
-     <property name="toolTip">
-      <string>Suffix of the window name used for detecting the terminal.</string>
-     </property>
-     <property name="statusTip">
-      <string>Window name suffix</string>
-     </property>
-     <property name="whatsThis">
-      <string>Window name suffix</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0">
-    <widget class="QCheckBox" name="kcfg_debugLoggingEnabled">
-     <property name="text">
-      <string>Debug logging?</string>
-     </property>
-    </widget>
-   </item>
-  </layout>
- </widget>
- <resources/>
- <connections/>
+    <resources/>
+    <connections/>
 </ui>

--- a/contents/ui/config.ui
+++ b/contents/ui/config.ui
@@ -1,68 +1,98 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-    <class>KWin::ToggleTerminalConfigForm</class>
-    <widget class="QWidget" name="KWin::ToggleTerminalConfigForm">
-        <layout class="QGridLayout">
-            <item row="0" column="0">
-                <widget class="QLabel">
-                    <property name="text">
-                        <string>Window name prefix</string>
-                    </property>
-                </widget>
-            </item>
-            <item row="1" column="0">
-                <widget class="QLineEdit" name="kcfg_windowNamePrefix">
-                    <property name="toolTip">
-                        <string>Prefix of the window name used for detecting the terminal.</string>
-                    </property>
-                    <property name="statusTip">
-                        <string>Window name prefix</string>
-                    </property>
-                    <property name="whatsThis">
-                        <string>Window name prefix</string>
-                    </property>
-                </widget>
-            </item>
-            <item row="2" column="0">
-                <widget class="QLabel">
-                    <property name="text">
-                        <string>Window name suffix</string>
-                    </property>
-                </widget>
-            </item>
-            <item row="3" column="0">
-                <widget class="QLineEdit" name="kcfg_windowNameSuffix">
-                    <property name="toolTip">
-                        <string>Suffix of the window name used for detecting the terminal.</string>
-                    </property>
-                    <property name="statusTip">
-                        <string>Window name suffix</string>
-                    </property>
-                    <property name="whatsThis">
-                        <string>Window name suffix</string>
-                    </property>
-                </widget>
-            </item>
-            <item row="4" column="0">
-                <widget class="QLabel">
-                    <property name="text">
-                        <string>Launch command</string>
-                    </property>
-                </widget>
-            </item>
-            <item row="5" column="0">
-                <widget class="QLineEdit" name="kcfg_launchCommand">
-                    <property name="toolTip">
-                        <string>Command for launching the terminal application if the window can not be found.</string>
-                    </property>
-                    <property name="statusTip">
-                        <string>Launch command</string>
-                    </property>
-                    <property name="whatsThis">
-                        <string>Launch command</string>
-                    </property>
-                </widget>
-            </item>
-        </layout>
+ <class>KWin::ToggleTerminalConfigForm</class>
+ <widget class="QWidget" name="KWin::ToggleTerminalConfigForm">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>147</width>
+    <height>254</height>
+   </rect>
+  </property>
+  <layout class="QGridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Window name prefix</string>
+     </property>
     </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Launch command</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLineEdit" name="kcfg_windowClassName">
+     <property name="toolTip">
+      <string>Name of the window class used for detecting the terminal.</string>
+     </property>
+     <property name="statusTip">
+      <string>Window class</string>
+     </property>
+     <property name="whatsThis">
+      <string>Window name suffix</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLineEdit" name="kcfg_launchCommand">
+     <property name="toolTip">
+      <string>Command for launching the terminal application if the window can not be found.</string>
+     </property>
+     <property name="statusTip">
+      <string>Launch command</string>
+     </property>
+     <property name="whatsThis">
+      <string>Launch command</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLineEdit" name="kcfg_windowNamePrefix">
+     <property name="toolTip">
+      <string>Prefix of the window name used for detecting the terminal.</string>
+     </property>
+     <property name="statusTip">
+      <string>Window name prefix</string>
+     </property>
+     <property name="whatsThis">
+      <string>Window name prefix</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Window name suffix</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLineEdit" name="kcfg_windowNameSuffix">
+     <property name="toolTip">
+      <string>Suffix of the window name used for detecting the terminal.</string>
+     </property>
+     <property name="statusTip">
+      <string>Window name suffix</string>
+     </property>
+     <property name="whatsThis">
+      <string>Window name suffix</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <widget class="QCheckBox" name="kcfg_debugLoggingEnabled">
+     <property name="text">
+      <string>Debug logging?</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
 </ui>


### PR DESCRIPTION
Sorry for putting these all in a single PR. I can split them if you'd like.

This adds some features that I needed for my local env.

1. Add support for matching by class name. I use Wezterm, which prefers one use a window class to match what gets captured. Since I usually have another Wezterm instance open, this is necessary for me to ensure the script grabs the correct window.
2. Allow users to opt into hiding the window from the taskbar and switcher. I like my terminals to feel ephemeral, 
and there are a few messy Wezterm/Wayland interactions that preclude me from using window rules for this.

Additionally, to support debugging, I threw in some log statements that can be toggled on and off via config.

Thanks for making this script!